### PR TITLE
Added z-index overlap fix

### DIFF
--- a/dist/PublicLab.Editor.css
+++ b/dist/PublicLab.Editor.css
@@ -155,6 +155,7 @@ textarea.ple-textarea {
 .wk-prompt {
   border-radius: 10px;
   padding: 20px;
+  z-index: 2;
 }
 
 /* Following may be removed if this is resolved:


### PR DESCRIPTION
Followed instructions outlined in issue #232 of the original repository to add the z-index fix for the overlapping behaviour

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `rake test`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
